### PR TITLE
Fixed spelling mistakes on permissions

### DIFF
--- a/src/ChatCensor/Commands/AddWord.php
+++ b/src/ChatCensor/Commands/AddWord.php
@@ -32,7 +32,7 @@ class AddWord extends PluginBase implements CommandExecutor{
     	$fcmd = strtolower($cmd->getName());
     	switch($fcmd){
     		case "addword":
-    			if($sender->hasPermission("chatcensor.command.addword")){
+    			if($sender->hasPermission("chatcensor.commands.addword")){
     				if(isset($args[0])){
     					$args[0] = strtolower($args[0]);
     					//Check if word exists

--- a/src/ChatCensor/Commands/Mute.php
+++ b/src/ChatCensor/Commands/Mute.php
@@ -32,7 +32,7 @@ class Mute extends PluginBase implements CommandExecutor{
     	$fcmd = strtolower($cmd->getName());
     	switch($fcmd){
     		case "mute":
-    			if($sender->hasPermission("chatcensor.command.mute")){
+    			if($sender->hasPermission("chatcensor.commands.mute")){
     				if(isset($args[0])){
     					$args[0] = strtolower($args[0]);
     					//Check if player exists

--- a/src/ChatCensor/Commands/RemoveWord.php
+++ b/src/ChatCensor/Commands/RemoveWord.php
@@ -32,7 +32,7 @@ class RemoveWord extends PluginBase implements CommandExecutor{
     	$fcmd = strtolower($cmd->getName());
     	switch($fcmd){
     		case "removeword":
-    			if($sender->hasPermission("chatcensor.command.removeword")){
+    			if($sender->hasPermission("chatcensor.commands.removeword")){
     				if(isset($args[0])){
     					$args[0] = strtolower($args[0]);
     					//Check if word exists

--- a/src/ChatCensor/Commands/Unmute.php
+++ b/src/ChatCensor/Commands/Unmute.php
@@ -32,7 +32,7 @@ class Unmute extends PluginBase implements CommandExecutor{
     	$fcmd = strtolower($cmd->getName());
     	switch($fcmd){
     		case "unmute":
-    			if($sender->hasPermission("chatcensor.command.unmute")){
+    			if($sender->hasPermission("chatcensor.commands.unmute")){
     				if(isset($args[0])){
     					$args[0] = strtolower($args[0]);
     					//Check if player exists


### PR DESCRIPTION
The check for some permissions was miss-pelt, corrected to its correct form on every file. 
_mute, unmute, addword & removeword_
That is: 
`chatcensor.command.addword` => `chatcensor.commands.addword`
`chatcensor.command.removeword` => `chatcensor.commands.removeword`
`chatcensor.command.mute` => `chatcensor.commands.mute`
`chatcensor.command.unmute` => `chatcensor.commands.unmute`
